### PR TITLE
added show-table command, for inspecting a NHCD Table

### DIFF
--- a/src/librvth/rvth.cpp
+++ b/src/librvth/rvth.cpp
@@ -557,6 +557,36 @@ bool RvtH::isHDD(void) const
 }
 
 /**
+ * Get the NHCD Table Header.
+ * @return NHCD Bank Table Header.
+ */
+NHCD_BankTable_Header* RvtH::nhcd_header(void) const
+{
+	NHCD_BankTable_Header *nhcd_header = nullptr;
+	// We won't have a header.
+	if (!this->isHDD()) {
+		return nhcd_header;
+	}
+	if (this->m_file == nullptr) {
+		return nhcd_header;
+	}
+
+	// Check the bank table header.
+	nhcd_header = (NHCD_BankTable_Header*)calloc(1, sizeof(NHCD_BankTable_Header));
+	size_t size = this->m_file->seekoAndRead(LBA_TO_BYTES(NHCD_BANKTABLE_ADDRESS_LBA), SEEK_SET,
+		nhcd_header, 1, sizeof(NHCD_BankTable_Header));
+	if (size != sizeof(NHCD_BankTable_Header)) {
+		// Short read.
+		if (errno == 0) {
+			errno = EIO;
+		}
+		return nullptr;
+	}
+
+	return nhcd_header;
+}
+
+/**
  * Get a bank table entry.
  * @param bank	[in] Bank number. (0-7)
  * @param pErr	[out,opt] Error code. (If negative, POSIX error; otherwise, see RvtH_Errors.)

--- a/src/librvth/rvth.hpp
+++ b/src/librvth/rvth.hpp
@@ -315,6 +315,19 @@ class RvtH {
 		NHCD_Status_e nhcd_status(void) const { return m_NHCD_status; }
 
 		/**
+		 * Get the NHCD Table Header.
+		 *
+		 * For any non HDD images this will always be a NULL pointer.
+		 * For HDD images this will be the raw bytes of the NHCD Bank Table Header.
+		 *
+		 * NOTE: the NHCD table may be wiped, and it may contain invalid, or
+		 * unexpected values.
+		 *
+		 * @return NHCD Bank Table Header.
+		 */
+		NHCD_BankTable_Header* nhcd_header(void) const;
+
+		/**
 		 * Get a bank table entry.
 		 * @param bank	[in] Bank number. (0-7)
 		 * @param pErr	[out,opt] Error code. (If negative, POSIX error; otherwise, see RvtH_Errors.)

--- a/src/rvthtool/CMakeLists.txt
+++ b/src/rvthtool/CMakeLists.txt
@@ -18,6 +18,7 @@ SET(rvthtool_SRCS
 	main.c
 	list-banks.cpp
 	extract.cpp
+	show-table.cpp
 	undelete.cpp
 	verify.cpp
 	query.c
@@ -25,6 +26,7 @@ SET(rvthtool_SRCS
 # Headers.
 SET(rvthtool_H
 	list-banks.hpp
+	show-table.hpp
 	extract.h
 	undelete.h
 	verify.h

--- a/src/rvthtool/main.c
+++ b/src/rvthtool/main.c
@@ -2,7 +2,7 @@
  * RVT-H Tool                                                              *
  * main.c: Main program file.                                              *
  *                                                                         *
- * Copyright (c) 2018-2022 by David Korth.                                 *
+ * Copyright (c) 2018-2023 by David Korth.                                 *
  * SPDX-License-Identifier: GPL-2.0-or-later                               *
  ***************************************************************************/
 
@@ -26,6 +26,7 @@
 #endif /* _WIN32 */
 
 #include "list-banks.hpp"
+#include "show-table.hpp"
 #include "extract.h"
 #include "undelete.h"
 #include "verify.h"
@@ -90,6 +91,9 @@ static void print_help(const TCHAR *argv0)
 		_T("\n")
 		_T("list rvth.img\n")
 		_T("- List banks in the specified RVT-H device or disk image.\n")
+		_T("\n")
+		_T("show-table rvth.img\n")
+		_T("- Print out the raw NHCD Bank Table information for debugging.\n")
 		_T("\n")
 		_T("extract ") _T(DEVICE_NAME_EXAMPLE) _T(" bank# disc.gcm\n")
 		_T("- Extract the specified bank number from rvth.img to disc.gcm.\n")
@@ -160,7 +164,7 @@ int RVTH_CDECL _tmain(int argc, TCHAR *argv[])
 	setlocale(LC_ALL, "");
 
 	_fputts(_T("RVT-H Tool v") _T(VERSION_STRING) _T("\n")
-		_T("Copyright (c) 2018-2022 by David Korth.\n")
+		_T("Copyright (c) 2018-2023 by David Korth.\n")
 		_T("This program is NOT licensed or endorsed by Nintendo Co., Ltd.\n"), stdout);
 #ifdef RP_GIT_VERSION
 	fputs(RP_GIT_VERSION "\n"
@@ -265,6 +269,13 @@ int RVTH_CDECL _tmain(int argc, TCHAR *argv[])
 			return EXIT_FAILURE;
 		}
 		ret = list_banks(argv[optind+1]);
+	} else if (!_tcscmp(argv[optind], _T("show-table"))) {
+		// Print raw table information.
+		if (argc < optind+2) {
+			print_error(argv[0], _T("RVT-H device or disk image not specified"));
+			return EXIT_FAILURE;
+		}
+		ret = show_table(argv[optind+1]);
 	} else if (!_tcscmp(argv[optind], _T("extract"))) {
 		// Extract a bank.
 		if (argc < optind+3) {

--- a/src/rvthtool/show-table.cpp
+++ b/src/rvthtool/show-table.cpp
@@ -1,0 +1,99 @@
+/***************************************************************************
+ * RVT-H Tool                                                              *
+ * show-table.cpp: Print out the NHCD Bank Table for debugging an invalid  *
+ * bank                                                                    *
+ *                                                                         *
+ * Copyright (c) 2023 by David Korth.                                      *
+ * SPDX-License-Identifier: GPL-2.0-or-later                               *
+ ***************************************************************************/
+
+#include "config.librvth.h"
+#include "show-table.hpp"
+
+#include "librvth/rvth.hpp"
+#include "librvth/rvth_error.h"
+#include "librvth/nhcd_structs.h"
+
+#include "libwiicrypto/byteswap.h"
+
+static void print_table(NHCD_BankTable_Header* header) {
+	_ftprintf(stdout, _T("- Table Magic (Expected Value: %d): %d\n"), be32_to_cpu(NHCD_BANKTABLE_MAGIC), header->magic);
+	_ftprintf(stdout, _T("- x004 (expected: 0x00000001): %d\n"), header->x004);
+	_ftprintf(stdout, _T("- bank_count (expected: 0x00000008): %d\n"), header->bank_count);
+	_ftprintf(stdout, _T("- x00C (expected: 0x00000000): %d\n"), header->x00C);
+	_ftprintf(stdout, _T("- x010 (expected: 0x002FF000): %d\n"), header->x010);
+
+	_fputts(_T("- unk table:\n"), stdout);
+	for (uint8_t row = 0; row < 12; ++row) {
+		uint16_t idx = row * 41;
+		_ftprintf(stdout, _T("  %d"), header->unk[idx]);
+		idx += 1;
+		for (; idx < (row + 1) * 41; ++idx) {
+			_ftprintf(stdout, _T(" %d"), header->unk[idx]);
+		}
+		_fputtc(_T('\n'), stdout);
+	}
+	_fputtc(_T('\n'), stdout);
+}
+
+/**
+ * 'show-table' command.
+ * @param rvth_filename RVT-H device or disk image filename.
+ * @return 0 on success; non-zero on error.
+ */
+int show_table(const TCHAR *rvth_filename)
+{
+	// Open the disk image.
+	int ret;
+	RvtH *const rvth = new RvtH(rvth_filename, &ret);
+	if (ret != 0 || !rvth->isOpen()) {
+		_ftprintf(stderr, _T("*** ERROR opening RVT-H device '%s': "), rvth_filename);
+		fputs(rvth_error(ret), stderr);
+		_fputtc(_T('\n'), stderr);
+		delete rvth;
+		return ret;
+	}
+
+	// Validate we're talking to an actual HDD image.
+	if (!rvth->isHDD()) {
+		_fputts(_T("*** ERROR can only print table information on an HDD.\n"), stderr);
+		delete rvth;
+		return 1;
+	}
+
+	// Print out the raw bank status.
+	_ftprintf(stdout, _T("[%s] NHCD Bank Table:\n"), rvth_filename);
+	_fputts(_T("- Status: "), stdout);
+	switch (rvth->nhcd_status()) {
+		case NHCD_STATUS_OK:
+			_fputts(_T("OK"), stdout);
+			break;
+		case NHCD_STATUS_UNKNOWN:
+			_fputts(_T("UNKNOWN"), stdout);
+			break;
+		case NHCD_STATUS_MISSING:
+			_fputts(_T("MISSING"), stdout);
+			break;
+		case NHCD_STATUS_HAS_MBR:
+			_fputts(_T("HAS_MBR"), stdout);
+			break;
+		case NHCD_STATUS_HAS_GPT:
+			_fputts(_T("HAS_GPT"), stdout);
+			break;
+		default:
+			_fputts(_T("???"), stdout);
+			break;
+	}
+	_fputtc(_T('\n'), stdout);
+
+	NHCD_BankTable_Header* header = rvth->nhcd_header();
+	if (header == nullptr) {
+		_fputts(_T("*** ERROR failed to read NHCD header image.\n"), stderr);
+		delete rvth;
+		return 1;
+	}
+	print_table(header);
+
+	delete rvth;
+	return 0;
+}

--- a/src/rvthtool/show-table.cpp
+++ b/src/rvthtool/show-table.cpp
@@ -17,19 +17,19 @@
 #include "libwiicrypto/byteswap.h"
 
 static void print_table(NHCD_BankTable_Header* header) {
-	_ftprintf(stdout, _T("- Table Magic (Expected Value: %d): %d\n"), be32_to_cpu(NHCD_BANKTABLE_MAGIC), header->magic);
-	_ftprintf(stdout, _T("- x004 (expected: 0x00000001): %d\n"), header->x004);
-	_ftprintf(stdout, _T("- bank_count (expected: 0x00000008): %d\n"), header->bank_count);
-	_ftprintf(stdout, _T("- x00C (expected: 0x00000000): %d\n"), header->x00C);
-	_ftprintf(stdout, _T("- x010 (expected: 0x002FF000): %d\n"), header->x010);
+	_ftprintf(stdout, _T("- Table Magic (Expected Value: 0x%#08x): 0x%#08x\n"), be32_to_cpu(NHCD_BANKTABLE_MAGIC), header->magic);
+	_ftprintf(stdout, _T("- x004 (expected: 0x00000001): 0x%#08x\n"), header->x004);
+	_ftprintf(stdout, _T("- bank_count (expected: 0x00000008): 0x%#08x\n"), header->bank_count);
+	_ftprintf(stdout, _T("- x00C (expected: 0x00000000): 0x%#08x\n"), header->x00C);
+	_ftprintf(stdout, _T("- x010 (expected: 0x002FF000): 0x%#08x\n"), header->x010);
 
 	_fputts(_T("- unk table:\n"), stdout);
-	for (uint8_t row = 0; row < 12; ++row) {
-		uint16_t idx = row * 41;
-		_ftprintf(stdout, _T("  %d"), header->unk[idx]);
+	for (uint8_t row = 0; row < 41; ++row) {
+		uint16_t idx = row * 12;
+		_ftprintf(stdout, _T("  %#02x"), header->unk[idx]);
 		idx += 1;
-		for (; idx < (row + 1) * 41; ++idx) {
-			_ftprintf(stdout, _T(" %d"), header->unk[idx]);
+		for (; idx < (row + 1) * 12; ++idx) {
+			_ftprintf(stdout, _T(" %#02x"), header->unk[idx]);
 		}
 		_fputtc(_T('\n'), stdout);
 	}

--- a/src/rvthtool/show-table.hpp
+++ b/src/rvthtool/show-table.hpp
@@ -1,0 +1,31 @@
+/***************************************************************************
+ * RVT-H Tool                                                              *
+ * show-table.hpp: Print out the NHCD Bank Table for debugging an invalid  *
+ * bank.                                                                   *
+ *                                                                         *
+ * Copyright (c) 2023 by David Korth.                                      *
+ * SPDX-License-Identifier: GPL-2.0-or-later                               *
+ ***************************************************************************/
+
+#ifndef __RVTHTOOL_RVTHTOOL_SHOW_TABLE_H__
+#define __RVTHTOOL_RVTHTOOL_SHOW_TABLE_H__
+
+#include "tcharx.h"
+#include "librvth/rvth.hpp"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * 'show-table' command.
+ * @param rvth_filename RVT-H device or disk image filename.
+ * @return 0 on success; non-zero on error.
+ */
+int show_table(const TCHAR *rvth_filename);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __RVTHTOOL_RVTHTOOL_SHOW_TABLE_H__ */


### PR DESCRIPTION
since you mentioned wanting to add in a command for repairing a NHCD Bank Table, I figured a command to inspect your current NHCD Bank Table would also be useful. even in the absence of a repair command, it still would be useful to see the bank table status. I was particularly curious if my RVT-H had it's bank fully zero'd or if only a few values were unexpected.

this only adds the command to the CLI, as displaying raw bytes in a QT window didn't feel like the best way to print that information. If you want there to be a UI before merging I understand, and can try playing around with QT to get something decent.