### PR TITLE
Fix compile error with newer clang

### DIFF
--- a/src/rvthtool/verify.cpp
+++ b/src/rvthtool/verify.cpp
@@ -96,13 +96,13 @@ static bool progress_callback(const RvtH_Verify_Progress_State *state, void *use
 				case RVTH_VERIFY_ERROR_BAD_HASH:
 					printf("\n*** ERROR: Pt%u [%u,%u,%u%s]: H%u hash is invalid.\n",
 						state->pt_current, state->group_cur,
-						state->sector / 8, state->sector,
+						state->sector / 8U, state->sector,
 						s_kb, state->hash_level);
 					break;
 				case RVTH_VERIFY_ERROR_TABLE_COPY:
 					printf("\n*** ERROR: Pt%u [%u,%u,%u%s]: H%u table copy doesn't match base sector.\n",
 						state->pt_current, state->group_cur,
-						state->sector / 8, state->sector,
+						state->sector / 8U, state->sector,
 						s_kb, state->hash_level);
 					break;
 			}


### PR DESCRIPTION
Build failed with clang 19 due to integer promotion.

```
/tmp/rvthtool/src/rvthtool/verify.cpp:99:7: error: format specifies type 'unsigned int' but the argument has type 'int' [-Werror,-Wformat]
   97 |                                         printf("\n*** ERROR: Pt%u [%u,%u,%u%s]: H%u hash is invalid.\n",
      |                                                                       ~~
      |                                                                       %d
   98 |                                                 state->pt_current, state->group_cur,
   99 |                                                 state->sector / 8, state->sector,
      |                                                 ^~~~~~~~~~~~~~~~~
/tmp/rvthtool/src/rvthtool/verify.cpp:105:7: error: format specifies type 'unsigned int' but the argument has type 'int' [-Werror,-Wformat]
  103 |                                         printf("\n*** ERROR: Pt%u [%u,%u,%u%s]: H%u table copy doesn't match base sector.\n",
      |                                                                       ~~
      |                                                                       %d
  104 |                                                 state->pt_current, state->group_cur,
  105 |                                                 state->sector / 8, state->sector,
      |                                                 ^~~~~~~~~~~~~~~~~
```